### PR TITLE
Fetch without --unshallow if necessary

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -4,4 +4,4 @@ set -euo pipefail
 
 cd ${BUILDKITE_BUILD_CHECKOUT_PATH}
 pwd
-git fetch --unshallow || true
+git fetch --unshallow || git fetch || true


### PR DESCRIPTION
Some jobs using this plugin fail with error:
```
fatal: --unshallow on a complete repository does not make sense
```

Possibly, the mirror already has a full clone, so the agent checks out a full clone. In that case, we just want to do a `git fetch`.