### PR TITLE
[FEP-2185] Add commit depth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # git-fetch-unshallow-buildkite-plugin
+
+A Buildkite plugin that performs a git fetch to make a shallow clone deeper.
+
+## Usage
+
+Add the following to your `pipeline.yml`:
+
+```yml
+steps:
+  - plugins:
+      - brexhq/git-fetch-unshallow#v1.0.0: {}
+```
+
+## Configuration
+
+### `GIT_FETCH_COMMIT_DEPTH` (optional, environment variable)
+
+Set this environment variable to specify the maximum commit depth for git fetch:
+
+```yml
+steps:
+  - env:
+      GIT_FETCH_COMMIT_DEPTH: "100"
+    plugins:
+      - brexhq/git-fetch-unshallow#v1.0.0: {}
+```
+
+If not specified, the plugin will perform a `git fetch --unshallow` operation to fetch all commits.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A Buildkite plugin that performs a git fetch to make a shallow clone deeper.
 
 ## Usage
 
-Add the following to your `pipeline.yml`:
+Add the following to your pipeline:
 
 ```yml
 steps:
   - plugins:
-      - brexhq/git-fetch-unshallow#v1.0.0: {}
+      - github.com/brexhq/git-fetch-unshallow-buildkite-plugin#v0.0.5
 ```
 
 ## Configuration
@@ -20,10 +20,10 @@ Set this environment variable to specify the maximum commit depth for git fetch:
 
 ```yml
 steps:
-  - env:
-      GIT_FETCH_COMMIT_DEPTH: "100"
-    plugins:
-      - brexhq/git-fetch-unshallow#v1.0.0: {}
+  - plugins:
+      - github.com/brexhq/git-fetch-unshallow-buildkite-plugin#v0.0.5:
+          env:
+            GIT_FETCH_COMMIT_DEPTH: 1000
 ```
 
 If not specified, the plugin will perform a `git fetch --unshallow` operation to fetch all commits.

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -4,4 +4,9 @@ set -euo pipefail
 
 cd ${BUILDKITE_BUILD_CHECKOUT_PATH}
 pwd
-git fetch --unshallow || git fetch || true
+
+if [ -n "${GIT_FETCH_COMMIT_DEPTH:-}" ]; then
+  git fetch --depth="${GIT_FETCH_COMMIT_DEPTH}" || git fetch || true
+else
+  git fetch --unshallow || git fetch || true
+fi


### PR DESCRIPTION
Adds a `GIT_FETCH_COMMIT_DEPTH` variable that allows callers to specify the `git fetch` commit depth.

## Context

[Slack thread with Chromatic](https://brex.slack.com/archives/C01JN31MZ0U/p1750300003569099?thread_ts=1749682337.006889&cid=C01JN31MZ0U)

`git fetch --unshallow` has been timing out on Chromatic pipelines, preventing Chromatic from detecting changed files and forcing it to run full builds without Turbosnap. This has consequently caused an uptick in snapshot volume putting us at risk of breaching our annual limit. By defining a max commit depth, we hope to mitigate `git fetch` timeouts and restore Turbosnap health.
